### PR TITLE
Added Get-ArubaCLTokenStatus 

### DIFF
--- a/PowerArubaCL/Private/RestMethod.ps1
+++ b/PowerArubaCL/Private/RestMethod.ps1
@@ -56,8 +56,7 @@ function Invoke-ArubaCLRestMethod {
         }
 
         #Check if the token will be expire on less of 15 minutes (or already expired)
-        $now = [int]((Get-Date -UFormat %s) -split ",")[0]
-        if (($connection.token.expire - $now) -le 15 * 60) {
+        if (Get-ArubaCLTokenStatus -timeout 15*60 -connection $connection) {
             Write-Warning "Token will expire soon, update token"
             Update-ArubaCLRefreshToken -connection $connection
         }

--- a/PowerArubaCL/Private/RestMethod.ps1
+++ b/PowerArubaCL/Private/RestMethod.ps1
@@ -56,7 +56,7 @@ function Invoke-ArubaCLRestMethod {
         }
 
         #Check if the token will be expire on less of 15 minutes (or already expired)
-        if (Get-ArubaCLTokenStatus -timeout 15*60 -connection $connection) {
+        if (-not (Get-ArubaCLTokenStatus -timeout (15 * 60) -connection $connection)) {
             Write-Warning "Token will expire soon, update token"
             Update-ArubaCLRefreshToken -connection $connection
         }

--- a/PowerArubaCL/Private/Token.ps1
+++ b/PowerArubaCL/Private/Token.ps1
@@ -36,6 +36,7 @@ function Update-ArubaCLRefreshToken {
     #Get when new token will be expire
     $connection.token.expire = [int]((Get-Date -UFormat %s) -split ",")[0] + $response.expires_in
 }
+
 function Get-ArubaCLTokenStatus {
     <#
     .SYNOPSIS
@@ -46,16 +47,20 @@ function Get-ArubaCLTokenStatus {
 
     .EXAMPLE
     Get-ArubaCLTokenStatus
-#>
+    #>
+
     Param(
         [Parameter(Mandatory = $false)]
         [psobject]$connection = $DefaultArubaCLConnection
     )
+
     $expire = $connection.token.expire
     $now = [int]((Get-Date -UFormat %s) -split ",")[0]
     if (($expire - $now) -le 0) {
         # If token is expired, it should fail boolean
         return $false
     }
-    else { return $true }
+    else {
+        return $true
+    }
 }

--- a/PowerArubaCL/Private/Token.ps1
+++ b/PowerArubaCL/Private/Token.ps1
@@ -36,3 +36,26 @@ function Update-ArubaCLRefreshToken {
     #Get when new token will be expire
     $connection.token.expire = [int]((Get-Date -UFormat %s) -split ",")[0] + $response.expires_in
 }
+function Get-ArubaCLTokenStatus {
+    <#
+    .SYNOPSIS
+    Get status of token
+
+    .DESCRIPTION
+    Get status of token so we don't need to keep reauthenticating
+
+    .EXAMPLE
+    Get-ArubaCLTokenStatus
+#>
+    Param(
+        [Parameter(Mandatory = $false)]
+        [psobject]$connection = $DefaultArubaCLConnection
+    )
+    $expire = $connection.token.expire
+    $now = [int]((Get-Date -UFormat %s) -split ",")[0]
+    if (($expire - $now) -le 0) {
+        # If token is expired, it should fail boolean
+        return $false
+    }
+    else { return $true }
+}

--- a/PowerArubaCL/Private/Token.ps1
+++ b/PowerArubaCL/Private/Token.ps1
@@ -47,16 +47,25 @@ function Get-ArubaCLTokenStatus {
 
     .EXAMPLE
     Get-ArubaCLTokenStatus
+
+    Get token status (expired or not)
+
+    .EXAMPLE
+    Get-ArubaCLTokenStatus -timeout 900
+
+    Get token status (expired or not) on less of 900 seconds (15 minutes)
     #>
 
     Param(
+        [Parameter(Mandatory = $false)]
+        [int]$timeout = 0,
         [Parameter(Mandatory = $false)]
         [psobject]$connection = $DefaultArubaCLConnection
     )
 
     $expire = $connection.token.expire
     $now = [int]((Get-Date -UFormat %s) -split ",")[0]
-    if (($expire - $now) -le 0) {
+    if (($expire - $now) -le $timeout) {
         # If token is expired, it should fail boolean
         return $false
     }

--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ Format-ArubaCLMacAddress
 Get-ArubaCLInventoryDevices
 Get-ArubaCLInventoryDevicesArchive
 Get-ArubaCLInventoryDevicesStats
+Get-ArubaCLTokenStatus
 Invoke-ArubaCLRestMethod
 Remove-ArubaCLInventoryDevicesArchive
 Set-ArubaCLCipherSSL
@@ -273,6 +274,7 @@ Update-ArubaCLRefreshToken
 
 - Cédric Moreau
 - cmcknz77
+- Zak
 
 Sort by name (*git shortlog -s*)
 


### PR DESCRIPTION
Added Get-ArubaCLTokenStatus allowing an easy call to determine if a new token/login is needed. This is needed because the refresh token logic is store within the native functions.